### PR TITLE
Ensured proper date formatting by setting explicite UK locale

### DIFF
--- a/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
+++ b/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
@@ -96,7 +96,7 @@ public class ModulrApiAuth {
     }
 
     private String getFormattedDate(Date date) {
-        DateFormat sdf = new SimpleDateFormat(DATE_PATTERN);
+        DateFormat sdf = new SimpleDateFormat(DATE_PATTERN,Locale.UK);
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
         return sdf.format(date);
     }


### PR DESCRIPTION
The example code could not work if the machine it was run on was in locale different than English / UK (e.g. Polish, Chinese, etc.)
The date format only makes sense when used with UK locale.