### PR TITLE
Adds Scala Hmac Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Please note the samples are designed to be self contained to demonstrate hmac si
 Samples directory contain sample code for the following languages:
 
 - [Java](#java)
+- [Scala](#scala)
 - [Kotlin](#kotlin)
 - [NodeJS](#nodejs)
 - [Postman](#postman-pre-request-script)
@@ -58,6 +59,37 @@ OR
 #### [com.modulr.hmac.Hmac.java](samples/java/src/main/java/com/modulr/hmac/Hmac.java)
 
 This class demonstrates how to use the ModulrApiAuth class.
+
+---
+
+### Scala
+
+#### [Signature.scala](samples/scala/src/main/scala/Signature.scala)
+
+This class is a helper that can generate required headers for a given value of API key and secret. It generates the following headers:
+
+- Authorization
+- Date
+- x-mod-nonce
+
+You can start by creating an instance of Signature class
+```scala
+  val signature: Signature = new Signature("key", "secret")
+```
+Then you can get your Auth headers by simply calling `.buildHeaders()`. In that case a nonce will be a random UUID and Date will default to current
+```scala
+  val headersDefault: Map[String, String] = signature.buildHeaders() 
+```
+OR with custom nonce
+```scala
+  val headersCustomNonce: Map[String, String] = signature.buildHeaders("nonceValue")
+```
+OR with both custom nonce and custom date 
+```scala
+  val headersCustomAll: Map[String, String] = signature.buildHeaders("nonceValue", Calendar.getInstance().getTime)
+```
+
+You can see all of it in action in [Main.scala](samples/scala/src/main/scala/Main.scala) class example
 
 ---
 

--- a/samples/scala/build.sbt
+++ b/samples/scala/build.sbt
@@ -1,0 +1,7 @@
+scalaVersion := "2.13.3"
+
+name := "modulr-hmac-example"
+organization := "ch.epfl.scala"
+version := "1.0"
+
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"

--- a/samples/scala/project/build.properties
+++ b/samples/scala/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.4.6

--- a/samples/scala/src/main/scala/Main.scala
+++ b/samples/scala/src/main/scala/Main.scala
@@ -1,0 +1,18 @@
+import java.util.Calendar
+
+object Main extends App {
+  val signature: Signature = new Signature("key", "secret")
+
+  //Option A: call with no input. Nonce will be a random UUID and Date will default to current
+  val headersDefault: Map[String, String] = signature.buildHeaders()
+
+  //Option B: Provide your own nonce, Date will be defaulted to current
+  val headersCustomNonce: Map[String, String] = signature.buildHeaders("nonceValue")
+
+  //Option C: Provide your own nonce and Date
+  val headersCustomAll: Map[String, String] = signature.buildHeaders("nonceValue", Calendar.getInstance().getTime)
+
+  headersDefault.foreach(println)
+  headersCustomNonce.foreach(println)
+  headersCustomAll.foreach(println)
+}

--- a/samples/scala/src/main/scala/Signature.scala
+++ b/samples/scala/src/main/scala/Signature.scala
@@ -1,0 +1,52 @@
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.{Base64, Calendar, Date, Locale, TimeZone, UUID}
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class Signature(val apiKey: String, val apiSecret: String) {
+
+  private val DatePattern: String = "EEE, dd MMM yyyy HH:mm:ss z"
+  private val HmacSha1Algorithm: String = "HmacSHA1"
+  private val AutorizationHeader: String = "Authorization"
+  private val DateHeader: String = "Date"
+  private val NonceHeader: String = "x-mod-nonce"
+
+  def buildHeaders(nonce: String = UUID.randomUUID().toString,
+                   date: Date = Calendar.getInstance().getTime): Map[String, String] = {
+    val timestamp = formatDate(date)
+    val signatureString = s"date: $timestamp\nx-mod-nonce: $nonce"
+
+    val hmacSignature = calculateHmac(signatureString)
+
+    Map(AutorizationHeader -> formatAuthHeader(apiKey, hmacSignature),
+      DateHeader -> timestamp,
+      NonceHeader -> nonce)
+  }
+
+  private def formatAuthHeader(key: String, signature: String): String = {
+    s"Signature keyId= ${'"'}$key${'"'}," +
+      s"algorithm=${'"'}hmac-sha1${'"'}," +
+      s"headers=${'"'}date x-mod-nonce${'"'}," +
+      s"signature=${'"'}$signature${'"'}"
+  }
+
+  private def calculateHmac(message: String): String = {
+    val signingKey = new SecretKeySpec(apiSecret.getBytes, HmacSha1Algorithm)
+
+    val mac = Mac.getInstance(HmacSha1Algorithm)
+    mac.init(signingKey)
+
+    val rawHmac = mac.doFinal(message.getBytes())
+    val hmac = Base64.getEncoder.encodeToString(rawHmac)
+    URLEncoder.encode(hmac, StandardCharsets.UTF_8.name())
+  }
+
+  private def formatDate(date: Date): String = {
+    val simpleDateFormat = new SimpleDateFormat(DatePattern, Locale.UK)
+    simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
+    simpleDateFormat.format(date)
+  }
+}


### PR DESCRIPTION
This adds a Scala helper class `Signature.scala` that generates Modulr Auth Headers for a given key/secret pair. 

Updates README file with a demostration of how to use `Signature.scala` class 