### PR TITLE
Check HTTP response code correctly in Ruby example

### DIFF
--- a/samples/ruby/example.rb
+++ b/samples/ruby/example.rb
@@ -25,7 +25,7 @@ Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
   res = http.request(req)
 end
 
-if res.code != 200
+if res.code != "200"
     puts "Unsuccessful API call, code: #{res.code}, body: #{res.body}"
 else
     puts res.body


### PR DESCRIPTION
The current check to see if the HTTP call was successfully will always fail.

It's checking for a response code of `200` - an integer.
Net::HTTPResponse [returns](https://ruby-doc.org/stdlib-2.7.0/libdoc/net/http/rdoc/Net/HTTPResponse.html#code) a string code, not an integer.