### PR TITLE
adjusted code in go example to work with different timezone by conveting to UTC by checking location

### DIFF
--- a/samples/go/hmac/hmac.go
+++ b/samples/go/hmac/hmac.go
@@ -1,9 +1,11 @@
 package hmac
 
 import (
+	"strings"
+	"time"
+
 	"github.com/Modulr-finance/modulr-hmac/hmac/signature"
 	"github.com/google/uuid"
-	"time"
 )
 
 const (
@@ -29,7 +31,15 @@ func GenerateHeaders(apiKey string, apiSecret string, nonce string, hasRetry boo
 
 func constructHeadersMap(apiKey string, apiSecret string, nonce string, hasRetry bool) map[string]string {
 	headers := make(map[string]string)
-	date := dateNow().Format(time.RFC1123)
+
+	// date should be sent UTC/GMT as per the docs https://modulr.readme.io/docs/authentication under section "System time"
+	var date string
+	if strings.EqualFold(dateNow().Location().String(), "GMT") {
+		date = dateNow().Format(time.RFC1123)
+	} else {
+		date = dateNow().UTC().Format(time.RFC1123)
+	}
+
 	nonce = generateNonceIfEmpty(nonce)
 
 	headers[DateHeader] = date


### PR DESCRIPTION
I have found that when I am running the code related to hmac calculations from my machine based in Berlin i am getting error as below

```400
{
    "error": "Authorization field missing, malformed or invalid"
}```


Later looking at the documentation here https://modulr.readme.io/docs/authentication understood that i need to convert time to UTC hence this PR for next person using this example from outside UK