### PR TITLE
Issue-29: Fix support for non UTC timezone

### DIFF
--- a/samples/go/hmac/hmac.go
+++ b/samples/go/hmac/hmac.go
@@ -29,7 +29,7 @@ func GenerateHeaders(apiKey string, apiSecret string, nonce string, hasRetry boo
 
 func constructHeadersMap(apiKey string, apiSecret string, nonce string, hasRetry bool) map[string]string {
 	headers := make(map[string]string)
-	date := dateNow().Format(time.RFC1123)
+	date := dateNow().UTC().Format(time.RFC1123)
 	nonce = generateNonceIfEmpty(nonce)
 
 	headers[DateHeader] = date

--- a/samples/go/hmac/hmac_test.go
+++ b/samples/go/hmac/hmac_test.go
@@ -12,10 +12,17 @@ func TestGenerateReturnsAnHMACString(t *testing.T) {
 	assert.Equal(t, expectedSignature, headers["Authorization"][0:86], "generate should return the hmac headers")
 }
 
-func TestGenerateReturnsADateHeader(t *testing.T) {
-	injectMockDate()
+func TestGenerateReturnsADateHeaderUTC(t *testing.T) {
+	injectMockUTCDate()
 	headers, _ := GenerateHeaders("api_key", "api_secret", "", false)
 	expectedDate := "Thu, 02 Jan 2020 15:04:05 GMT"
+	assert.Equal(t, expectedDate, headers["Date"])
+}
+
+func TestGenerateReturnsADateHeaderNonUTC(t *testing.T) {
+	injectMockNonUTCDate()
+	headers, _ := GenerateHeaders("api_key", "api_secret", "", false)
+	expectedDate := "Thu, 02 Jan 2020 14:04:05 GMT"
 	assert.Equal(t, expectedDate, headers["Date"])
 }
 
@@ -50,9 +57,16 @@ func TestGenerateThrowsErrorIfApiSecretIsNull(t *testing.T) {
 	assert.Equal(t, "api_secret cannot be empty", err.Message)
 }
 
-func injectMockDate() {
+func injectMockUTCDate() {
 	dateNow = func() time.Time {
 		now, _ := time.Parse(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 GMT")
+		return now
+	}
+}
+
+func injectMockNonUTCDate() {
+	dateNow = func() time.Time {
+		now, _ := time.Parse(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 CET")
 		return now
 	}
 }


### PR DESCRIPTION
Code assumed UTC as timezone, hence failed when running in non UTC timezones.

Convert timezone to UTC explicitly to add this support.

Fixes Issue#29