### PR TITLE
Issue 40 :  Format September dates correctly

### DIFF
--- a/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
+++ b/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
@@ -96,7 +96,7 @@ public class ModulrApiAuth {
     }
 
     private String getFormattedDate(Date date) {
-        DateFormat sdf = new SimpleDateFormat(DATE_PATTERN,Locale.UK);
+        DateFormat sdf = new SimpleDateFormat(DATE_PATTERN,Locale.ENGLISH);
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
         return sdf.format(date);
     }

--- a/samples/java/src/test/java/com/modulr/api/ModulrApiAuthTest.java
+++ b/samples/java/src/test/java/com/modulr/api/ModulrApiAuthTest.java
@@ -23,11 +23,11 @@ import static org.junit.Assert.*;
 public class ModulrApiAuthTest {
 
     /* Test Data*/
-    private static final String DATE_STR = "2016-07-25T16:36:07";
+    private static final String DATE_STR = "2016-09-25T16:36:07";
     private static final String API_TOKEN = "KNOWN-TOKEN";
     private static final String HMAC_SECRET = "NzAwZmIwMGQ0YTJiNDhkMzZjYzc3YjQ5OGQyYWMzOTI=";
     private static final String NONCE = "28154b2-9c62b93cc22a-24c9e2-5536d7d";
-    private static final String EXPECTED_HMAC_SIGNATURE = "WBMr%2FYdhysbmiIEkdTrf2hP7SfA%3D";
+    private static final String EXPECTED_HMAC_SIGNATURE = "z1X8UZJq9jwLPi9peycdHfy3SIY%3D";
 
     @Mock
     Supplier<Date> dateSupplier;

--- a/samples/kotlin/src/main/kotlin/com/modulr/api/Signature.kt
+++ b/samples/kotlin/src/main/kotlin/com/modulr/api/Signature.kt
@@ -44,7 +44,7 @@ class Signature(
         private const val HMAC_SHA1_ALGORITHM = "HmacSHA1"
 
         private fun formatDate(date: Date): String {
-            val sdf = SimpleDateFormat(DATE_PATTERN, Locale.UK)
+            val sdf = SimpleDateFormat(DATE_PATTERN, Locale.ENGLISH)
             sdf.timeZone = TimeZone.getTimeZone("GMT")
             return sdf.format(date)
         }

--- a/samples/kotlin/src/test/kotlin/com/modulr/api/SignatureTest.kt
+++ b/samples/kotlin/src/test/kotlin/com/modulr/api/SignatureTest.kt
@@ -29,16 +29,16 @@ class SignatureTest {
 
     @Test
     fun testHmacGenerationWithKnownNonceAndDate() {
-        val result = signature.calculate("28154b2-9c62b93cc22a-24c9e2-5536d7d", toDate("2016-07-25T16:36:07"))
+        val result = signature.calculate("28154b2-9c62b93cc22a-24c9e2-5536d7d", toDate("2016-09-25T16:36:07"))
 
         assertEquals("28154b2-9c62b93cc22a-24c9e2-5536d7d", result.nonce)
-        assertEquals("WBMr%2FYdhysbmiIEkdTrf2hP7SfA%3D", result.signature)
-        assertEquals("Mon, 25 Jul 2016 16:36:07 GMT", result.timestamp)
+        assertEquals("z1X8UZJq9jwLPi9peycdHfy3SIY%3D", result.signature)
+        assertEquals("Sun, 25 Sep 2016 16:36:07 GMT", result.timestamp)
 
         val headers = result.headers
 
-        assertEquals("Signature keyId=\"${API_KEY}\",algorithm=\"hmac-sha1\",headers=\"date x-mod-nonce\",signature=\"WBMr%2FYdhysbmiIEkdTrf2hP7SfA%3D\"", headers["Authorization"])
-        assertEquals("Mon, 25 Jul 2016 16:36:07 GMT", headers["Date"])
+        assertEquals("Signature keyId=\"${API_KEY}\",algorithm=\"hmac-sha1\",headers=\"date x-mod-nonce\",signature=\"z1X8UZJq9jwLPi9peycdHfy3SIY%3D\"", headers["Authorization"])
+        assertEquals("Sun, 25 Sep 2016 16:36:07 GMT", headers["Date"])
         assertEquals("28154b2-9c62b93cc22a-24c9e2-5536d7d", headers["x-mod-nonce"])
     }
 


### PR DESCRIPTION
As per https://bugs.openjdk.org/browse/JDK-8281302 date formatting breaks when using Locale.UK. Closes #40 