### PR TITLE
Make the Java header generation stateless and thread-safe

### DIFF
--- a/samples/java/build.gradle
+++ b/samples/java/build.gradle
@@ -4,7 +4,7 @@ version '1.0'
 apply plugin: 'java'
 
 java {
-    sourceCompatibility = 1.8
+    sourceCompatibility = 17
 }
 
 repositories {
@@ -12,7 +12,12 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
-    testImplementation 'org.mockito:mockito-core:5.11.0'
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
+	testImplementation "org.junit.jupiter:junit-jupiter-api:5.13.4"
+	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.13.4"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.13.4"
+}
+
+test {
+	useJUnitPlatform()
 }

--- a/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
+++ b/samples/java/src/main/java/com/modulr/api/ModulrApiAuth.java
@@ -1,113 +1,102 @@
 package com.modulr.api;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SignatureException;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SignatureException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.function.Supplier;
 
 public class ModulrApiAuth {
-    private static final String HMAC_SHA1_ALGORITHM = "HmacSHA1";
+
     private static final String DATE_PATTERN = "EEE, dd MMM yyyy HH:mm:ss z";
-    private final String secret;
-    private final String token;
-    private Date date;
-    private Supplier<Date> dateSupplier;
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_PATTERN, Locale.ENGLISH).withZone(ZoneId.of("GMT"));
 
-    private String lastUsedNonce;
+    private final String keyId;
+    private final String hmacSecret;
+    private final Clock clock;
+    private final HmacAlgorithm hmacAlgorithm;
 
-
-    public ModulrApiAuth(String token, String secret) {
-        this(token, secret, Date::new);
+    public ModulrApiAuth(String keyId, String hmacSecret) {
+        this(keyId, hmacSecret, Clock.systemUTC(), HmacAlgorithm.SHA512);
     }
 
-    public ModulrApiAuth(String token, String secret, Supplier<Date> dateSupplier) {
-        this.token = (token != null) ? token.trim() : null;
-        this.secret = secret.trim();
-        this.dateSupplier = dateSupplier;
+    public ModulrApiAuth(String keyId, String hmacSecret, Clock clock, HmacAlgorithm hmacAlgorithm) {
+        this.keyId = Optional.ofNullable(keyId).orElseThrow(() -> new IllegalArgumentException("KeyId cannot be null"));
+        this.hmacSecret = Optional.ofNullable(hmacSecret).orElseThrow(() -> new IllegalArgumentException("HmacSecret cannot be null"));
+        this.clock = Optional.ofNullable(clock).orElseThrow(() -> new IllegalArgumentException("Clock cannot be null"));
+        this.hmacAlgorithm = Optional.ofNullable(hmacAlgorithm).orElseThrow(() -> new IllegalArgumentException("HmacAlgorithm cannot be null"));
     }
 
     public Map<String, String> generateApiAuthHeaders(String nonce) throws SignatureException {
-        return buildHeaders(nonce, false);
+        return generateApiAuthHeaders(nonce, false);
     }
 
-    public Map<String, String> generateRetryApiAuthHeaders() throws SignatureException {
-        return buildHeaders(this.lastUsedNonce, true);
+    public Map<String, String> generateApiAuthHeaders(String nonce, boolean isReplay) throws SignatureException {
+        String formattedDate = DATE_TIME_FORMATTER.format(clock.instant().atZone(ZoneId.of("GMT")));
+        String signature = generateSignature(nonce, formattedDate);
+
+        return Map.of("Authorization", formatAuthHeader(keyId, signature, hmacAlgorithm),
+                "Date", formattedDate,
+                "x-mod-nonce", nonce,
+                "x-mod-retry", String.valueOf(isReplay));
     }
 
-    private Map<String, String> buildHeaders(String nonce, Boolean retry) throws SignatureException {
-        final Map<String, String> headerParams = new HashMap<>();
-        String hmac = generateHmac(nonce);
-
-        headerParams.put("Authorization", formatAuthHeader(this.token, hmac));
-        headerParams.put("Date", getFormattedDate(this.getDate()));
-        headerParams.put("x-mod-nonce", nonce);
-        headerParams.put("x-mod-retry", String.valueOf(retry));
-
-        this.lastUsedNonce = nonce;
-
-        return headerParams;
-    }
-
-    public String generateHmac(String nonce) throws SignatureException {
-        validateFields();
-        this.date = dateSupplier.get();
-        String data = String.format("date: %s\nx-mod-nonce: %s", getFormattedDate(this.getDate()), nonce);
+    @SuppressWarnings("java:S3457") // System specific line separators are required in the HMAC signature specification
+    private String generateSignature(String nonce, String formattedDate) throws SignatureException {
+        String data = String.format("date: %s\nx-mod-nonce: %s", formattedDate, nonce);
         return calculateHmac(data);
     }
 
-    public Date getDate() {
-        return date;
-    }
-
-    public String getSecret() {
-        return secret;
-    }
-
-    public String getToken() {
-        return token;
-    }
-
-    private String formatAuthHeader(String token, String signature) {
-        return String.format("Signature keyId=\"%s\",algorithm=\"%s\",headers=\"date x-mod-nonce\",signature=\"%s\"", token, "hmac-sha1", signature);
-    }
-
-    private String calculateHmac(final String content) throws SignatureException {
+    private String calculateHmac(String content) throws SignatureException {
         try {
-            final SecretKeySpec signingKey = new SecretKeySpec(secret.getBytes(), HMAC_SHA1_ALGORITHM);
-            Mac mac = Mac.getInstance(HMAC_SHA1_ALGORITHM);
+            SecretKeySpec signingKey = new SecretKeySpec(hmacSecret.getBytes(StandardCharsets.UTF_8), hmacAlgorithm.getJavaAlgorithmName());
+            Mac mac = Mac.getInstance(hmacAlgorithm.getJavaAlgorithmName());
             mac.init(signingKey);
 
-            // compute the hmac on input data bytes
-            byte[] rawHmac = mac.doFinal(content.getBytes());
+            byte[] rawHmac = mac.doFinal(content.getBytes(StandardCharsets.UTF_8));
 
-            // base64-encode the hmac
             String hmac = Base64.getEncoder().encodeToString(rawHmac);
-            return URLEncoder.encode(hmac, "UTF-8");
-        } catch (NoSuchAlgorithmException | InvalidKeyException | UnsupportedEncodingException e) {
-            throw new SignatureException("Failed to generate HMAC : " + e.getMessage(), e);
+            return URLEncoder.encode(hmac, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new SignatureException("Failed to generate HMAC: " + e.getMessage(), e);
         }
     }
 
-    private String getFormattedDate(Date date) {
-        DateFormat sdf = new SimpleDateFormat(DATE_PATTERN,Locale.ENGLISH);
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-        return sdf.format(date);
+    private static String formatAuthHeader(String keyId, String signature, HmacAlgorithm algorithm) {
+        return String.format("Signature keyId=\"%s\",algorithm=\"%s\",headers=\"date x-mod-nonce\",signature=\"%s\"", keyId, algorithm.getApiName(), signature);
     }
 
-    private void validateFields() {
-        if (this.secret == null) {
-            throw new IllegalStateException("Secret required for Modulr API Auth");
+    public enum HmacAlgorithm {
+        SHA1("HmacSha1", "hmac-sha1"),
+        SHA256("HmacSha256", "hmac-sha256"),
+        SHA384("HmacSha384", "hmac-sha384"),
+        SHA512("HmacSha512", "hmac-sha512");
+
+        private final String javaAlgorithmName;
+        private final String apiName;
+
+        HmacAlgorithm(String javaAlgorithmName, String apiName) {
+            this.javaAlgorithmName = javaAlgorithmName;
+            this.apiName = apiName;
         }
-        if (this.dateSupplier == null) {
-            throw new IllegalStateException("A date supplier is required for Modulr API Auth");
+
+        public String getJavaAlgorithmName() {
+            return javaAlgorithmName;
         }
+
+        public String getApiName() {
+            return apiName;
+        }
+
     }
 
 }

--- a/samples/java/src/main/java/com/modulr/api/TestAPI.java
+++ b/samples/java/src/main/java/com/modulr/api/TestAPI.java
@@ -4,48 +4,47 @@ import java.io.IOException;
 import java.security.SignatureException;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Logger;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.routing.RoutingSupport;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
-
-// Small demo program to perform a API get call on an account on the Modulr sanbox.
+// Small demo program to perform an API get call on an account on the Modulr sandbox.
 // Replace the api key value with your api-key.
 // Replace the secret with your secret key.
 // Replace the account id with your account id.
 // This can be run from your favorite IDE.
 public class TestAPI {
 
-    private static final String accountId = "<YOUR ACCOUNT ID>"; // Will be of the format A120940C
-    private static final String MODULR_URL = "https://api-sandbox.modulrfinance.com/api-sandbox/accounts/" + accountId;
-    private static final String api_key = "<YOUR KEY>";
-    private static final String secret = "<YOUR SECRET>";
+    private static final Logger logger = Logger.getLogger(TestAPI.class.getName());
 
-    public static void main(String[] args) throws SignatureException {
-        ModulrApiAuth auth = new ModulrApiAuth(api_key, secret);
+    private static final String ACCOUNT_ID = "<YOUR ACCOUNT ID>"; // Will be of the format A120940C
+    private static final String MODULR_URL = "https://api-sandbox.modulrfinance.com/api-sandbox/accounts/" + ACCOUNT_ID;
+    private static final String API_KEY_ID = "<YOUR KEY>";
+    private static final String API_KEY_SECRET = "<YOUR SECRET>";
+
+    public static void main(String[] args) throws SignatureException, IOException, HttpException {
+        ModulrApiAuth auth = new ModulrApiAuth(API_KEY_ID, API_KEY_SECRET);
         String nonce = UUID.randomUUID().toString();
         Map<String, String> headers = auth.generateApiAuthHeaders(nonce);
 
-        CloseableHttpClient client = HttpClients.createDefault();
-        RequestBuilder builder = RequestBuilder.get()
-            .setUri(MODULR_URL);
-        headers.keySet().forEach(k -> {
-            builder.addHeader(k, headers.get(k));
-        });
-        headers.keySet().forEach(k-> {
-            System.out.println(k + " " + headers.get(k));
-        });
-        HttpUriRequest request = builder.build();
-        try {
-            CloseableHttpResponse response = client.execute(request);
-            System.out.println(response.getStatusLine());
-            System.out.println(EntityUtils.toString(response.getEntity()));
-        } catch (IOException e) {
-            e.printStackTrace();
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            ClassicRequestBuilder builder = ClassicRequestBuilder.get().setUri(MODULR_URL);
+            headers.keySet().forEach(k -> builder.addHeader(k, headers.get(k)));
+            headers.keySet().forEach(k -> logger.info(k + " " + headers.get(k)));
+            ClassicHttpRequest request = builder.build();
+            try (ClassicHttpResponse response = client.executeOpen(RoutingSupport.determineHost(request), request, null)) {
+                logger.info(() -> response.getVersion().toString() + " " + response.getCode() + " " + response.getReasonPhrase());
+                String responseBody = EntityUtils.toString(response.getEntity());
+                logger.info(responseBody);
+            }
         }
     }
 }

--- a/samples/java/src/main/java/com/modulr/hmac/Hmac.java
+++ b/samples/java/src/main/java/com/modulr/hmac/Hmac.java
@@ -4,19 +4,23 @@ import com.modulr.api.ModulrApiAuth;
 
 import java.util.Map;
 import java.security.SignatureException;
+import java.util.logging.Logger;
 
 public class Hmac {
-    public static void main(String... args) throws SignatureException{
+
+    private static final Logger logger = Logger.getLogger(Hmac.class.getName());
+
+    public static void main(String... args) throws SignatureException {
         ModulrApiAuth modulrAuth = new ModulrApiAuth("KNOWN-TOKEN", "SECRET-TOKEN");
 
         /* Generate required headers for the given API key, hmac secret and nonce*/
         Map<String, String> headers = modulrAuth.generateApiAuthHeaders("NONCE");
 
-        headers.forEach((key, value) -> System.out.println(key + ": " + value));
+        headers.forEach((key, value) -> logger.info(key + ": " + value));
 
         /* Generate required headers for the given API key, hmac secret and last used nonce*/
-        Map<String, String> retryHeaders = modulrAuth.generateRetryApiAuthHeaders();
+        Map<String, String> retryHeaders = modulrAuth.generateApiAuthHeaders("NONCE", true);
 
-        retryHeaders.forEach((key, value) -> System.out.println(key + ": " + value));
+        retryHeaders.forEach((key, value) -> logger.info(key + ": " + value));
     }
 }


### PR DESCRIPTION
The Java `ModulrApiAuth` implementation is currently persisting a `date` and `lastUsedNonce` in fields, but without any synchronisation or locking across the objects that update or use those fields. This could result in signature being generated using a date, but that date then being replaced by another thread, and the new date being used in the `Date` header, so not matching the timestamp used in the signature.

To overcome this, `ModulrApiAuth` has been altered to be immutable, to use nonces passed into the method, and to store dates locally rather than in fields. Additionally, the implementation has been switched to use Java time APIs to allow the use of thread-safe formatters, time-zone aware handling of dates, and a Clock for supplying current datetime instances.

Includes an upgrade to the latest major version of all dependencies.