### PR TITLE
#46: Ensure dates are generated in GMT rather than UTC

### DIFF
--- a/samples/go/hmac/hmac.go
+++ b/samples/go/hmac/hmac.go
@@ -29,7 +29,7 @@ func GenerateHeaders(apiKey string, apiSecret string, nonce string, hasRetry boo
 
 func constructHeadersMap(apiKey string, apiSecret string, nonce string, hasRetry bool) map[string]string {
 	headers := make(map[string]string)
-	date := dateNow().UTC().Format(time.RFC1123)
+	date := dateNow().In(time.FixedZone("GMT", 0)).Format(time.RFC1123)
 	nonce = generateNonceIfEmpty(nonce)
 
 	headers[DateHeader] = date

--- a/samples/go/hmac/hmac_test.go
+++ b/samples/go/hmac/hmac_test.go
@@ -59,14 +59,16 @@ func TestGenerateThrowsErrorIfApiSecretIsNull(t *testing.T) {
 
 func injectMockUTCDate() {
 	dateNow = func() time.Time {
-		now, _ := time.Parse(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 GMT")
+		location, _ := time.LoadLocation("Europe/London")
+		now, _ := time.ParseInLocation(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 GMT", location)
 		return now
 	}
 }
 
 func injectMockNonUTCDate() {
+	location, _ := time.LoadLocation("Europe/Berlin")
 	dateNow = func() time.Time {
-		now, _ := time.Parse(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 CET")
+		now, _ := time.ParseInLocation(time.RFC1123, "Mon, 02 Jan 2020 15:04:05 CET", location)
 		return now
 	}
 }


### PR DESCRIPTION
The code was converting dates to UTC before attempting to format the value for the signature, however the signature requires the timezone to be formatted with GMT. The handling has therefore been altered to use GMT and to update the tests to set specific timezones since GoLang doesn't parse the timezone out of a formatted timestamp.